### PR TITLE
fix publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,9 @@
 name: publish
 on:
   # When Release Pull Request is merged
-  pull_request:
+  push:
     branches:
       - master
-    types: [closed]
-
 env:
   CI: true
 jobs:


### PR DESCRIPTION
Currently, it is set to publish when the pull request is `closed`, but this is different than `merged`.

On pull_request to master branch merged, push to master branch will happen, so this is what we want.